### PR TITLE
nyc-server-update

### DIFF
--- a/electrums/NYC
+++ b/electrums/NYC
@@ -8,3 +8,4 @@
     "ws_url": "electrum.newyorkcoin.online:50004"
   }
 ]
+nyc


### PR DESCRIPTION
This PR adds a new ElectrumX server for NewYorkCoin:

- Host: electrum.newyorkcoin.online
- SSL: 50002
- WSS: 50004
- Contact: admin@newyorkcoin.online
- Server running on 8GB RAM instance, replacing old 4GB server